### PR TITLE
Remove constructor

### DIFF
--- a/countdown-timer/src/App.js
+++ b/countdown-timer/src/App.js
@@ -2,30 +2,6 @@ import React, { Component } from 'react';
 import CountdownClock from './components/CountdownClock';
 import DateDropdown from './components/DateDropdown';
 
-// The options get passed into the DateDropdown
-const INITIAL_STATE = {
-  options: [
-    {
-      name: 'Tomorrow',
-      date: new Date('May 29, 2018 00:00:00')
-    },
-    {
-      name: 'Canada Day 2018',
-      date: new Date('July 1, 2018 00:00:00')
-    },
-    {
-      name: 'Christmas 2018',
-      date: new Date('December 25, 2018 00:00:00')
-    },
-    {
-      name: 'New Year 2019',
-      date: new Date('January 1, 2019 00:00:00')
-    }
-  ],
-  // Notice that selected starts off as 'null' in this stage.
-  selected: null
-}
-
 class App extends Component {
   // As per React convention, we initialize the state inside the constructor
   constructor() {

--- a/countdown-timer/src/App.js
+++ b/countdown-timer/src/App.js
@@ -3,11 +3,29 @@ import CountdownClock from './components/CountdownClock';
 import DateDropdown from './components/DateDropdown';
 
 class App extends Component {
-  // As per React convention, we initialize the state inside the constructor
-  constructor() {
-    super();
-    this.state = INITIAL_STATE;
-  }
+  // As per React convention, we initialize the state here
+  this.state = {
+    options: [
+      {
+        name: 'Tomorrow',
+        date: new Date('May 29, 2018 00:00:00')
+      },
+      {
+        name: 'Canada Day 2018',
+        date: new Date('July 1, 2018 00:00:00')
+      },
+      {
+        name: 'Christmas 2018',
+        date: new Date('December 25, 2018 00:00:00')
+      },
+      {
+        name: 'New Year 2019',
+        date: new Date('January 1, 2019 00:00:00')
+      }
+    ],
+    // Notice that selected starts off as 'null' in this stage.
+    selected: null
+  };
 
   // As per React convention, this method handles the onChange event
   // that is forwarded up by the DateDropdown.

--- a/countdown-timer/src/App.js
+++ b/countdown-timer/src/App.js
@@ -4,7 +4,7 @@ import DateDropdown from './components/DateDropdown';
 
 class App extends Component {
   // As per React convention, we initialize the state here
-  this.state = {
+  state = {
     options: [
       {
         name: 'Tomorrow',


### PR DESCRIPTION
The goal is to clean up the code a bit while also getting rid of the constructor. This way, you can avoid having to explain what a constructor is and what `super()` does.